### PR TITLE
Clarify encryption password warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -160,8 +160,7 @@ async function main(): Promise<void> {
   }
 
   if (!process.env.ACTUAL_ENC_PASSWORD) {
-    console.warn('ACTUAL_ENC_PASSWORD is not set.');
-    console.warn('Encrypted budgets require ACTUAL_ENC_PASSWORD; initialization will fail without it.');
+    console.error('Warning: ACTUAL_ENC_PASSWORD is not set. This is required for encrypted budgets, and initialization will fail without it.');
   }
 
   if (useSse) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -160,8 +160,8 @@ async function main(): Promise<void> {
   }
 
   if (!process.env.ACTUAL_ENC_PASSWORD) {
-    console.error('Note: ACTUAL_ENC_PASSWORD is not set.');
-    console.error('If your budget file is encrypted, initialization will fail.');
+    console.warn('ACTUAL_ENC_PASSWORD is not set.');
+    console.warn('Encrypted budgets require ACTUAL_ENC_PASSWORD; initialization will fail without it.');
   }
 
   if (useSse) {


### PR DESCRIPTION
## Summary
- warn instead of error when ACTUAL_ENC_PASSWORD is missing
- clarify that warning only applies to encrypted budgets

## Testing
- `npm test`
- `npm run lint` (warning)


------
https://chatgpt.com/codex/tasks/task_e_68c6c3c30450832299a565b1e1ed3f87